### PR TITLE
Fix: Correct spelling errors in error messages and comments

### DIFF
--- a/ir_cli/README.md
+++ b/ir_cli/README.md
@@ -60,7 +60,7 @@ ir_cli sol2tensor $input_dir_absolute_path
 | ├- file2.json
 | └- ...
 └- output
-  ├- source_info -- infomation about contract
+  ├- source_info -- information about contract
   ├- standard_input -- solc compiler standard input json
   ├- standard_output -- solc compiler standard output json
   ├- yul -- yul src code

--- a/smart_ir/src/ir/pass_manager.rs
+++ b/smart_ir/src/ir/pass_manager.rs
@@ -215,7 +215,7 @@ impl<IRUnit: 'static> AnalysisManager<IRUnit> {
                     .downcast_rc::<AnalysisImpl::AnalysisResult>()
                     .unwrap_or_else(|_| {
                         panic!(
-                            "cast analysis resulst to {} failed",
+                            "cast analysis results to {} failed",
                             std::any::type_name::<AnalysisImpl::AnalysisResult>()
                         )
                     })

--- a/smart_ir/src/linker/wasm.rs
+++ b/smart_ir/src/linker/wasm.rs
@@ -208,7 +208,7 @@ pub fn link(
     // remove empty initializers
     if let Some(data_section) = module.data_section_mut() {
         let _entries = data_section.entries_mut();
-        // TODO: can't rm the entries directly when mulitple modules
+        // TODO: can't rm the entries directly when multiple modules
         // let mut index = 0;
         // while index < entries.len() {
         //     if entries[index].value().iter().all(|b| *b == 0) {

--- a/smart_ir/src/runtime/vm/mod.rs
+++ b/smart_ir/src/runtime/vm/mod.rs
@@ -65,7 +65,7 @@ impl VirtualMachine {
             },
             code,
             addr,
-            op_addr: Address::from("opration address"),
+            op_addr: Address::from("operation address"),
         }
     }
 }


### PR DESCRIPTION
  ## Summary
This PR fixes minor spelling mistakes found in the codebase to improve code clarity and consistency.



### **Error Message Fix**
- **File:** `smart_ir/src/ir/pass_manager.rs`
- **Change:** Corrected typo from "resulst" → "results" in panic error message

### **Comment Fix**  
- **File:** `smart_ir/src/linker/wasm.rs`
- **Change:** Fixed typo from "mulitple" → "multiple" in TODO comment

### **Address String Fix**
- **File:** `smart_ir/src/runtime/vm/mod.rs`
- **Change:** Corrected typo from "opration" → "operation" in address string

