### PR TITLE
fix: typos in IR codegen comments and error message

### DIFF
--- a/smart_ir/src/ir_codegen/context.rs
+++ b/smart_ir/src/ir_codegen/context.rs
@@ -1151,7 +1151,7 @@ impl<'ctx> IR2LLVMCodeGenContext<'ctx> {
         // }
 
         for ir_module in &self.ir_modules {
-            // scan all module's func defintions to use in other modules
+            // scan all module's func definitions to use in other modules
             for (_, function) in &ir_module.functions {
                 self.func_definitions.borrow_mut().push(function.clone());
             }

--- a/smart_ir/src/ir_codegen/ir.rs
+++ b/smart_ir/src/ir_codegen/ir.rs
@@ -513,7 +513,7 @@ impl<'ctx> IR2LLVMCodeGenContext<'ctx> {
                             } else {
                                 return Err(CodeGenError {
                                 message:
-                                    "try to get field from a pointer whose elemet isn't a struct"
+                                    "try to get field from a pointer whose element isn't a struct"
                                         .to_string(),
                             });
                             }


### PR DESCRIPTION

Minor wording fixes to improve clarity in IR codegen. 

