### PR TITLE
fix: correct typos and grammar in README and Contributing Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Release][release-shield]][release-url] [![Issues][issues-shield]][issues-url] [![PR][pr-shield]][pr-url] [![Apache License][license-shield]][license-url]
 
-The Smart Intermediate Representation(short for IR) project is a new compiler framework intended for smart contract development, which is mainly inspired by LLVM, MLIR and Solidity/Yul. The compiler's goals are:
+The Smart Intermediate Representation (short for IR) project is a new compiler framework intended for smart contract development, which is mainly inspired by LLVM, MLIR and Solidity/Yul. The compiler's goals are:
 
 * Trust and Security
 * Rollup Friendly

--- a/doc/Contributing Guide.md
+++ b/doc/Contributing Guide.md
@@ -77,7 +77,7 @@ A good principle: "Work together, share ideas, teach others."
 
 ### Sign the CLA
 
-Since the first time you push a PR request as a contributor, you will be asked to sign a CLA (Contributor License Agreement), please following the instruction to comment in such PR.
+Since the first time you push a PR request as a contributor, you will be asked to sign a CLA (Contributor License Agreement), please follow the instruction to comment in such PR.
 
 ### Important Note
 


### PR DESCRIPTION


Fixed minor typographical and grammatical errors in documentation files.

